### PR TITLE
updated ejs to 2.5.5

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1559,9 +1559,9 @@
       }
     },
     "ejs": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/ejs/-/ejs-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-1.0.0.tgz"
+      "version": "2.5.5",
+      "from": "https://registry.npmjs.org/ejs/-/ejs-2.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.5.tgz"
     },
     "express": {
       "version": "4.9.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bower": "^1.3.12",
     "cookie-parser": "^1.3.3",
     "debug": "^2.0.0",
-    "ejs": "^1.0.0",
+    "ejs": "^2.5.5",
     "express": "^4.9.4",
     "express-session": "^1.8.2",
     "grunt": "^0.4.5",


### PR DESCRIPTION
Updated ejs version to 2.5.5 because the old version had a security issue.

Please make sure the site runs without any problem. You can check totem as well.